### PR TITLE
Fix compilation on GCC 4.9.0

### DIFF
--- a/src/ngx_http_psgi_input_stream.c
+++ b/src/ngx_http_psgi_input_stream.c
@@ -50,7 +50,7 @@ PerlIONginxInput_read(pTHX_ PerlIO *f, void *vbuf, Size_t count)
         return 0;
     }
 
-    len = len > count ? count : len;
+    len = len > (off_t)count ? (off_t)count : len;
 
     Copy(r->request_body->bufs->buf->pos + st->pos, vbuf, len, STDCHAR);
 


### PR DESCRIPTION
Probably not the greatest fix but somehow either count needs to be signed, or length unsigned.

Fixes the following:

/home/jraspass/ngx_mod_psgi/src/ngx_http_psgi_input_stream.c: In function ‘PerlIONginxInput_read’:
/home/jraspass/ngx_mod_psgi/src/ngx_http_psgi_input_stream.c:53:15: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     len = len > count ? count : len;
               ^
/home/jraspass/ngx_mod_psgi/src/ngx_http_psgi_input_stream.c:53:31: error: signed and unsigned type in conditional expression [-Werror=sign-compare]
     len = len > count ? count : len;
